### PR TITLE
xdebug

### DIFF
--- a/bin/php7.4.30/php.ini
+++ b/bin/php7.4.30/php.ini
@@ -1978,7 +1978,7 @@ include_path=".;~BEARSAMPP_LIN_PATH~/bin/php/php7.4.30/pear/pear"
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php7.4.30/php.ini.ber
+++ b/bin/php7.4.30/php.ini.ber
@@ -1978,7 +1978,7 @@ include_path=".;~BEARSAMPP_LIN_PATH~/bin/php/php7.4.30/pear/pear"
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php7.4.32/php.ini
+++ b/bin/php7.4.32/php.ini
@@ -1978,7 +1978,7 @@ include_path=".;~BEARSAMPP_LIN_PATH~/bin/php/php7.4.32/pear/pear"
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php7.4.32/php.ini.ber
+++ b/bin/php7.4.32/php.ini.ber
@@ -1978,7 +1978,7 @@ include_path=".;~BEARSAMPP_LIN_PATH~/bin/php/php7.4.32/pear/pear"
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php7.4.33/php.ini
+++ b/bin/php7.4.33/php.ini
@@ -1978,7 +1978,7 @@ include_path=".;~BEARSAMPP_LIN_PATH~/bin/php/php7.4.33/pear/pear"
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php7.4.33/php.ini.ber
+++ b/bin/php7.4.33/php.ini.ber
@@ -1978,7 +1978,7 @@ include_path=".;~BEARSAMPP_LIN_PATH~/bin/php/php7.4.33/pear/pear"
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.0.21/php.ini
+++ b/bin/php8.0.21/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.0.22/php.ini
+++ b/bin/php8.0.22/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.0.23/php.ini
+++ b/bin/php8.0.23/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.0.24/php.ini
+++ b/bin/php8.0.24/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.0.25/php.ini
+++ b/bin/php8.0.25/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.0.26/php.ini
+++ b/bin/php8.0.26/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.0.27/php.ini
+++ b/bin/php8.0.27/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.0.28/php.ini
+++ b/bin/php8.0.28/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.0.29/php.ini
+++ b/bin/php8.0.29/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.0.30/php.ini
+++ b/bin/php8.0.30/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.10/php.ini
+++ b/bin/php8.1.10/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.11/php.ini
+++ b/bin/php8.1.11/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.12/php.ini
+++ b/bin/php8.1.12/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.13/php.ini
+++ b/bin/php8.1.13/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.14/php.ini
+++ b/bin/php8.1.14/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.16/php.ini
+++ b/bin/php8.1.16/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.17/php.ini
+++ b/bin/php8.1.17/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.21/php.ini
+++ b/bin/php8.1.21/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.23/php.ini
+++ b/bin/php8.1.23/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.27/php.ini
+++ b/bin/php8.1.27/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.28/php.ini
+++ b/bin/php8.1.28/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.30/php.ini
+++ b/bin/php8.1.30/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.8/php.ini
+++ b/bin/php8.1.8/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.1.9/php.ini
+++ b/bin/php8.1.9/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.0/php.ini
+++ b/bin/php8.2.0/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.1/php.ini
+++ b/bin/php8.2.1/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.10/php.ini
+++ b/bin/php8.2.10/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.14/php.ini
+++ b/bin/php8.2.14/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.17/php.ini
+++ b/bin/php8.2.17/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.18/php.ini
+++ b/bin/php8.2.18/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.18/php.ini.ber
+++ b/bin/php8.2.18/php.ini.ber
@@ -1969,7 +1969,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.19/php.ini
+++ b/bin/php8.2.19/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.19/php.ini.ber
+++ b/bin/php8.2.19/php.ini.ber
@@ -1969,7 +1969,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.3/php.ini
+++ b/bin/php8.2.3/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.4/php.ini
+++ b/bin/php8.2.4/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.2.8/php.ini
+++ b/bin/php8.2.8/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.1/php.ini
+++ b/bin/php8.3.1/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.11/php.ini
+++ b/bin/php8.3.11/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.11/php.ini.ber
+++ b/bin/php8.3.11/php.ini.ber
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.12/php.ini
+++ b/bin/php8.3.12/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.12/php.ini.ber
+++ b/bin/php8.3.12/php.ini.ber
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.4/php.ini
+++ b/bin/php8.3.4/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.6/php.ini
+++ b/bin/php8.3.6/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.6/php.ini.ber
+++ b/bin/php8.3.6/php.ini.ber
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.7/php.ini
+++ b/bin/php8.3.7/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.7/php.ini.ber
+++ b/bin/php8.3.7/php.ini.ber
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.9/php.ini
+++ b/bin/php8.3.9/php.ini
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/bin/php8.3.9/php.ini.ber
+++ b/bin/php8.3.9/php.ini.ber
@@ -1949,7 +1949,7 @@ opcache.enable_cli=0
 
 [xdebug]
 zend_extension = "xdebug"
-xdebug.mode = debug, develop, trace
+xdebug.mode = debug
 xdebug.start_with_request = trigger
 xdebug.output_name = cachegrind.out.%t.%p
 xdebug.output_dir = "~BEARSAMPP_LIN_PATH~/tmp/cachegrind"

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 bundle.name = php
 
-bundle.release = 2024.10.2
+bundle.release = 2024.11.30
 
 bundle.type = bins
 bundle.format = 7z


### PR DESCRIPTION
### **User description**
xdebug fix.


___

### **PR Type**
enhancement


___

### **Description**
- Updated `xdebug.mode` in multiple PHP configuration files to only include `debug`, removing `develop` and `trace` modes.
- This change affects various PHP versions, ensuring a consistent debugging setup.
- Updated the `bundle.release` in `build.properties` to `2024.11.30`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 7.4.30</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php7.4.30/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-abc55a14d56a35c07385859475be3fb8038a8b8b21b2e403e9e5fac3327388b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini.ber</strong><dd><code>Simplified xdebug mode configuration for PHP 7.4.30 backup</code></dd></summary>
<hr>

bin/php7.4.30/php.ini.ber

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-ca95da386dc311697348d878f40a628abdfc4d335421fca5f5aa608c7902d492">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 7.4.32</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php7.4.32/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-8bd5b9c6658b8cc6a533dc66f44481d0b2e014edb8261c4547e8775e29540e9f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini.ber</strong><dd><code>Simplified xdebug mode configuration for PHP 7.4.32 backup</code></dd></summary>
<hr>

bin/php7.4.32/php.ini.ber

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-4d79aea9e970d1a6e67bffb30690fb1647e86872acb0ee9369810f4cac7574f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 7.4.33</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php7.4.33/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-600f4d4e22e3ef9d7d4963c338bae8e5ab260bccb015f8d392ad20d3ae26ce66">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini.ber</strong><dd><code>Simplified xdebug mode configuration for PHP 7.4.33 backup</code></dd></summary>
<hr>

bin/php7.4.33/php.ini.ber

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-39e148216324b40bc8753b218a2c1ac81b09b002cb51e93b6cb185ea2ffff052">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 8.0.21</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php8.0.21/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-859d30dd9b848340575e3484fd21ad2c39b47d09dd37e12a508aac0cca434a80">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 8.0.22</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php8.0.22/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-96d51e5a606e998c619b89e822dd35fa25bdca8fce54df594148eebae45a6463">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 8.0.23</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php8.0.23/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-42ce4239647838af132164f586bcd9e65fdef83bf8d9682a1ab5e19e8d1e6229">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 8.0.24</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php8.0.24/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-29e561e53c251217aa11b542f9e95d0b246a4b6a37b3e86419032957f66a9028">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 8.0.25</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php8.0.25/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-6a8c1c9d5ef8a6dd4fe3eb3bf2423c2e8062af49b8cbe1a0ddd8da851364877e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 8.0.26</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php8.0.26/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-f1e8f3a536cdd015074bc84dd10f5cbea7c21857fe301d6357843d8791c85045">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 8.0.27</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php8.0.27/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-4a0dedb6e2bd4bd016a1b85d0be03cd779efa56d2aae9e546a9fe853573fad1c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 8.0.28</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php8.0.28/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-05fe0533f20fcbb71df9bad07331b5eb159140882d301a228623670eb2850396">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Simplified xdebug mode configuration for PHP 8.0.29</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php8.0.29/php.ini

- Updated `xdebug.mode` to only include `debug`.



</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/45/files#diff-433e6afa592af914884cab9fbae5e6cb06ff61a2fb8d0aebaf8f76c09523ff6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information