### PR TITLE
.ini hotfix

### DIFF
--- a/bin/php8.4.3/php.ini
+++ b/bin/php8.4.3/php.ini
@@ -765,7 +765,7 @@ user_dir =
 ;extension_dir = "./"
 ; On windows:
 ;extension_dir = "ext"
-extension_dir = "~BEARSAMPP_LIN_PATH~/bin/php/php8.4.1/ext"
+extension_dir = "~BEARSAMPP_LIN_PATH~/bin/php/php8.4.3/ext"
 
 ; Directory where the temporary files should be placed.
 ; Defaults to the system default (see sys_get_temp_dir)
@@ -1724,7 +1724,7 @@ ldap.max_links = -1
 
 ; OPCache
 
-zend_extension = "~BEARSAMPP_LIN_PATH~/bin/php/php8.4.1/ext/php_opcache.dll"
+zend_extension = "~BEARSAMPP_LIN_PATH~/bin/php/php8.4.3/ext/php_opcache.dll"
 
 [opcache]
 ; Determines if Zend OPCache is enabled

--- a/bin/php8.4.3/php.ini
+++ b/bin/php8.4.3/php.ini
@@ -741,7 +741,7 @@ default_charset = "UTF-8"
 ;include_path = ".;c:\php\includes"
 
 ;***** Added by go-pear
-include_path=".;~BEARSAMPP_LIN_PATH~/bin/php/php8.4.1/pear/pear"
+include_path=".;~BEARSAMPP_LIN_PATH~/bin/php/php8.4.3/pear/pear"
 ;*****
 ;
 ; PHP's default setting for include_path is ".;/path/to/php/pear"

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 bundle.name = php
 
-bundle.release = 2025.2.11
+bundle.release = 2025.2.18
 
 bundle.type = bins
 bundle.format = 7z

--- a/build.xml
+++ b/build.xml
@@ -168,7 +168,6 @@
           </filterset>
           <resources>
             <file file = "${bundle.path}/php.ini" />
-            <file file = "${bundle.path}/php.ini.ber" />
           </resources>
         </copy>
 
@@ -181,7 +180,6 @@
           </filterset>
           <resources>
             <file file = "${bundle.path}/php.ini" />
-            <file file = "${bundle.path}/php.ini.ber" />
           </resources>
         </copy>
       </else>

--- a/releases.properties
+++ b/releases.properties
@@ -52,4 +52,4 @@
 8.3.14 = https://github.com/Bearsampp/module-php/releases/download/2024.12.15/bearsampp-php-8.3.14-2024.12.15.7z
 8.3.16 = https://github.com/Bearsampp/module-php/releases/download/2025.2.11/bearsampp-php-8.3.16-2025.2.11.7z
 8.4.1 = https://github.com/Bearsampp/module-php/releases/download/2025.2.11/bearsampp-php-8.4.1-2025.2.11.7z
-8.4.3 = https://github.com/Bearsampp/module-php/releases/download/2025.2.11/bearsampp-php-8.4.3-2025.2.11.7z
+8.4.3 = https://github.com/Bearsampp/module-php/releases/download/2025.2.18/bearsampp-php-8.4.3-2025.2.18.7z


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated `include_path` in `php.ini` to correct version.

- Removed redundant `php.ini.ber` file references in `build.xml`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>php.ini</strong><dd><code>Corrected `include_path` version in `php.ini`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/php8.4.3/php.ini

<li>Updated <code>include_path</code> to reference <code>php8.4.3</code> instead of <code>php8.4.1</code>.


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/50/files#diff-3b624cb5843288742ceb88260f4f7ecc20cc0e6da576b24d9699282cc05e09be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build.xml</strong><dd><code>Removed redundant `php.ini.ber` references in `build.xml`</code></dd></summary>
<hr>

build.xml

<li>Removed references to <code>php.ini.ber</code> file.<br> <li> Cleaned up redundant file handling logic.


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-php/pull/50/files#diff-766797f233c18114f9499750cf1ffbf3829aeea50283850619c01bd173132021">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>