### PR TITLE
Add zip extension support for PHP 8.3.30, 8.4.18, and 8.5.3 and updat…

### DIFF
--- a/bin/php8.3.30/exts.properties
+++ b/bin/php8.3.30/exts.properties
@@ -1,3 +1,4 @@
 imagick=https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php_imagick-3.8.1-8.3-ts-vs16-x86_64.zip
 memcache=https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php-8.3.x_memcache.dll
 xdebug=https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.1.16/php_xdebug-3.5.0-8.3-ts-vs16-x86_64.dll
+zip = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.13/php_zip-1.22.8-8.3-ts-vs16-x64.zip

--- a/bin/php8.4.18/exts.properties
+++ b/bin/php8.4.18/exts.properties
@@ -1,3 +1,4 @@
 imagick=https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_imagick-3.7.0-8.4-ts-vs17-x64.zip
 memcache=https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_memcache-8.2-8.4-ts-vs17-x64.1.zip
 xdebug=https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_xdebug-3.5.1-8.4-ts-vs17-x86_64.dll
+zip = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.13/php_zip-1.22.8-8.4-ts-vs17-x64.zip

--- a/bin/php8.5.3/exts.properties
+++ b/bin/php8.5.3/exts.properties
@@ -1,3 +1,4 @@
 imagick=https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_imagick-3.8.1-8.5-ts-vs17-x64.zip
 memcache=https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_memcache-8.2-8.5-ts-vs17-x64.zip
 xdebug=https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.4/php_xdebug-3.5.1-8.5-ts-vs17-x86_64.dll
+zip = https://github.com/Bearsampp/modules-untouched/releases/download/php-2026.3.13/php_zip-1.22.8-8.5-ts-vs17-x64.zip

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 bundle.name = php
-bundle.release = 2026.3.4
+bundle.release = 2026.3.13
 bundle.type = bins
 bundle.format = 7z
 


### PR DESCRIPTION
…e bundle release to 2026.3.13
we've had zip as a selectable extension forever but for some reaosn its always been off by default and is not listed in the php.ini as a valid extension.
This resolves that. 
It makes it active by default to satisfy akeeba issues.