### PR TITLE
Update releases.properties from release 2026.7.7

### DIFF
--- a/releases.properties
+++ b/releases.properties
@@ -1,8 +1,10 @@
+8.5.8 = https://github.com/Bearsampp/module-php/releases/download/2026.7.7/bearsampp-php-8.5.8-2026.7.7.7z
 8.5.7 = https://github.com/Bearsampp/module-php/releases/download/2026.6.2/bearsampp-php-8.5.7-2026.6.2.7z
 8.5.5 = https://github.com/Bearsampp/module-php/releases/download/2026.4.18/bearsampp-php-8.5.5-2026.4.18.7z
 8.5.3 = https://github.com/Bearsampp/module-php/releases/download/2026.3.4/bearsampp-php-8.5.3-2026.3.4.7z
 8.5.2 = https://github.com/Bearsampp/module-php/releases/download/2026.1.30/bearsampp-php-8.5.2-2026.1.30.7z
 8.5.0 = https://github.com/Bearsampp/module-php/releases/download/2025.12.7/bearsampp-php-8.5.0-2025.12.07.7z
+8.4.23 = https://github.com/Bearsampp/module-php/releases/download/2026.7.7/bearsampp-php-8.4.23-2026.7.7.7z
 8.4.22 = https://github.com/Bearsampp/module-php/releases/download/2026.6.2/bearsampp-php-8.4.22-2026.6.2.7z
 8.4.20 = https://github.com/Bearsampp/module-php/releases/download/2026.4.18/bearsampp-php-8.4.20-2026.4.18.7z
 8.4.18 = https://github.com/Bearsampp/module-php/releases/download/2026.3.4/bearsampp-php-8.4.18-2026.3.4.7z
@@ -17,6 +19,7 @@
 8.4.4 = https://github.com/Bearsampp/module-php/releases/download/2025.2.20/bearsampp-php-8.4.4-2025.2.20.7z
 8.4.3 = https://github.com/Bearsampp/module-php/releases/download/2025.2.18/bearsampp-php-8.4.3-2025.2.18.7z
 8.4.1 = https://github.com/Bearsampp/module-php/releases/download/2025.2.11/bearsampp-php-8.4.1-2025.2.11.7z
+8.3.32 = https://github.com/Bearsampp/module-php/releases/download/2026.7.7/bearsampp-php-8.3.32-2026.7.7.7z
 8.3.31 = https://github.com/Bearsampp/module-php/releases/download/2026.6.2/bearsampp-php-8.3.31-2026.6.2.7z
 8.3.30 = https://github.com/Bearsampp/module-php/releases/download/2026.1.16/bearsampp-php-8.3.30-2026.1.16.7z
 8.3.28 = https://github.com/Bearsampp/module-php/releases/download/2025.12.7/bearsampp-php-8.3.28-2025.12.07.7z
@@ -41,7 +44,6 @@
 8.2.27 = https://github.com/Bearsampp/module-php/releases/download/2025.2.11/bearsampp-php-8.2.27-2025.2.11.7z
 8.2.26 = https://github.com/Bearsampp/module-php/releases/download/2024.12.15/bearsampp-php-8.2.26-2024.12.15.7z
 8.2.24 = https://github.com/Bearsampp/module-php/releases/download/2024.11.30/bearsampp-php-8.2.4-2024.11.30.7z
-8.2.23 = https://github.com/Bearsampp/module-php/releases/download/2024.9.14/bearsampp-php-8.2.23-2024.9.14.7z
 8.2.21 = https://github.com/Bearsampp/module-php/releases/download/2024.7.11/bearsampp-php-8.2.21-2024.7.12.7z
 8.2.19 = https://github.com/Bearsampp/module-php/releases/download/2024.11.30/bearsampp-php-8.2.19-2024.11.30.7z
 8.2.18 = https://github.com/Bearsampp/module-php/releases/download/2024.11.30/bearsampp-php-8.2.18-2024.11.30.7z


### PR DESCRIPTION
## 🤖 Automated Releases Properties Update

This PR updates the `releases.properties` file with new versions from release `2026.7.7`.

### Changes:
- Extracted .7z assets from the release
- Removed stale/invalid existing URLs from `releases.properties`
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/module-php/releases/tag/2026.7.7

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, review logs for transient network/service issues