### PR TITLE
Update releases.properties from release 2026.8.6

### DIFF
--- a/releases.properties
+++ b/releases.properties
@@ -1,9 +1,11 @@
+8.5.9 = https://github.com/Bearsampp/module-php/releases/download/2026.8.6/bearsampp-php-8.5.9-2026.8.6.7z
 8.5.8 = https://github.com/Bearsampp/module-php/releases/download/2026.7.7/bearsampp-php-8.5.8-2026.7.7.7z
 8.5.7 = https://github.com/Bearsampp/module-php/releases/download/2026.6.2/bearsampp-php-8.5.7-2026.6.2.7z
 8.5.5 = https://github.com/Bearsampp/module-php/releases/download/2026.4.18/bearsampp-php-8.5.5-2026.4.18.7z
 8.5.3 = https://github.com/Bearsampp/module-php/releases/download/2026.3.4/bearsampp-php-8.5.3-2026.3.4.7z
 8.5.2 = https://github.com/Bearsampp/module-php/releases/download/2026.1.30/bearsampp-php-8.5.2-2026.1.30.7z
 8.5.0 = https://github.com/Bearsampp/module-php/releases/download/2025.12.7/bearsampp-php-8.5.0-2025.12.07.7z
+8.4.24 = https://github.com/Bearsampp/module-php/releases/download/2026.8.6/bearsampp-php-8.4.24-2026.8.6.7z
 8.4.23 = https://github.com/Bearsampp/module-php/releases/download/2026.7.7/bearsampp-php-8.4.23-2026.7.7.7z
 8.4.22 = https://github.com/Bearsampp/module-php/releases/download/2026.6.2/bearsampp-php-8.4.22-2026.6.2.7z
 8.4.20 = https://github.com/Bearsampp/module-php/releases/download/2026.4.18/bearsampp-php-8.4.20-2026.4.18.7z
@@ -19,6 +21,7 @@
 8.4.4 = https://github.com/Bearsampp/module-php/releases/download/2025.2.20/bearsampp-php-8.4.4-2025.2.20.7z
 8.4.3 = https://github.com/Bearsampp/module-php/releases/download/2025.2.18/bearsampp-php-8.4.3-2025.2.18.7z
 8.4.1 = https://github.com/Bearsampp/module-php/releases/download/2025.2.11/bearsampp-php-8.4.1-2025.2.11.7z
+8.3.33 = https://github.com/Bearsampp/module-php/releases/download/2026.8.6/bearsampp-php-8.3.33-2026.8.6.7z
 8.3.32 = https://github.com/Bearsampp/module-php/releases/download/2026.7.7/bearsampp-php-8.3.32-2026.7.7.7z
 8.3.31 = https://github.com/Bearsampp/module-php/releases/download/2026.6.2/bearsampp-php-8.3.31-2026.6.2.7z
 8.3.30 = https://github.com/Bearsampp/module-php/releases/download/2026.1.16/bearsampp-php-8.3.30-2026.1.16.7z
@@ -38,6 +41,7 @@
 8.3.6 = https://github.com/Bearsampp/module-php/releases/download/2024.11.30/bearsampp-php-8.3.6-2024.11.30.7z
 8.3.4 = https://github.com/Bearsampp/module-php/releases/download/2024.11.30/bearsampp-php-8.3.4-2024.11.30.7z
 8.3.1 = https://github.com/Bearsampp/module-php/releases/download/2024.11.30/bearsampp-php-8.3.1-2024.11.30.7z
+8.2.33 = https://github.com/Bearsampp/module-php/releases/download/2026.8.6/bearsampp-php-8.2.33-2026.8.6.7z
 8.2.30 = https://github.com/Bearsampp/module-php/releases/download/2026.1.16/bearsampp-php-8.2.30-2026.1.16.7z
 8.2.29 = https://github.com/Bearsampp/module-php/releases/download/2025.8.21/bearsampp-php-8.2.29-2025.8.20.7z
 8.2.28 = https://github.com/Bearsampp/module-php/releases/download/2025.4.8/bearsampp-php-8.2.28-2025.4.8.7z


### PR DESCRIPTION
## 🤖 Automated Releases Properties Update

This PR updates the `releases.properties` file with new versions from release `2026.8.6`.

### Changes:
- Extracted .7z assets from the release
- Removed stale/invalid existing URLs from `releases.properties`
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/module-php/releases/tag/2026.8.6

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, review logs for transient network/service issues